### PR TITLE
chore(NA): remove support for 7.10 branch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ app.get('/jobs', async (req, res, next) => {
 app.get('/es-snapshots', async (req, res, next) => {
   console.log(`Request for ${req.path}`);
 
-  const branches = ['master', '7.x', '7.12', '7.11', '7.10', '6.8'];
+  const branches = ['master', '7.x', '7.12', '7.11', '6.8'];
   try {
     const data = await esSnapshots.getInfoForBranches(BASE_URL, branches);
     res.json(data);


### PR DESCRIPTION
@brianseeders I didn't realise on the previous PR we can also remove `7.10` now. Looks like no more releases are planned for it.